### PR TITLE
Windows: Fix iframe fails to load in Joplin 3.3.5

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { ContentScriptType, SettingItemType, MenuItem, MenuItemLocation, DialogR
 import { isDiagramResource } from './resources'
 import { createDiagramResource, getDiagramResource, updateDiagramResource } from './resources';
 import { ToolbarButtonLocation } from 'api/types';
-import { tmpdir } from 'os'
+import { platform, tmpdir } from 'os'
 import { sep } from 'path'
 const fs = joplin.require('fs-extra')
 
@@ -20,6 +20,12 @@ const CommandsId = {
 // 插入markdown语句
 function diagramMarkdown(diagramId: string) {
 	return `![mindmap](:/${diagramId})`
+}
+
+function escapeQuotes(text: string) {
+	return text
+		.replace(/["]/g, '&quot;')
+		.replace(/[']/g, '&#39;');
 }
 
 // 创建dlg内嵌form
@@ -71,6 +77,14 @@ joplin.plugins.register({
 			}
 		})
 
+		function getIframePath() {
+			let iframePath = `${app_path}\\local-kity-minder\\index.html`;
+			if (platform() === 'win32') {
+				iframePath = `/${iframePath}`;
+			}
+			return iframePath;
+		}
+
 		async function open_edit_dlg(data_json: string, diagramId: string, type: string = "addnew") {
 			let dialogs = joplin.views.dialogs;
 			let language = await joplin.settings.value('language') as string;
@@ -78,7 +92,12 @@ joplin.plugins.register({
 
 			let header = buildDialogHTML(data_json, language);
 			console.log("header", header);
-			let iframe = `<iframe id="mindmap_iframe" style="position:absolute;border:0;width:100%;height:100%;" src="${app_path}\\local-kity-minder\\index.html" title="description"></iframe>`
+			let iframe = `<iframe
+				id="mindmap_iframe"
+				style="position:absolute;border:0;width:100%;height:100%;"
+				src="${escapeQuotes(getIframePath())}"
+				title="description"
+			></iframe>`;
 			await dialogs.setHtml(handle_dlg, header +iframe);
 
 			await dialogs.setButtons(handle_dlg, [


### PR DESCRIPTION
# Summary

\[ [Upstream issue](https://github.com/laurent22/joplin/issues/12143) \] | \[ [Build workflow with test .JPL](https://github.com/personalizedrefrigerator/fork-kminder-Mindmap-Joplin-Plugin/actions/runs/14604668071) \]

This pull request fixes a Windows-specific compatibility issue with Joplin 3.3.5.

See https://github.com/laurent22/joplin/issues/12143.

# Details

The incompatibility was caused by a [security-related change in how Joplin loads plugin panels and dialogs](https://github.com/laurent22/joplin/pull/12083) -- plugin panels and dialogs now use `joplin-content://.../some/path/here`-style URLs, rather than `file://` URLs.

On Windows, the path used for the main `<iframe>` has format `C:\Users\<username>\.config\joplin-desktop\cache\<plugin id>\index.html`. Even without a leading `file://`, Electron interprets `C:\...` paths as `file://` paths. Loading assets from `file://` URLs is blocked from `joplin-content://` URLs. This prevented the main `<iframe>` from loading.

MacOS and Linux use `/home/user-name/.config/joplin-desktop/...`-style paths. Electron interprets these as paths relative to the toplevel domain (`joplin-content://plugin-webview/`).

# Testing plan

**Linux (OpenSUSE)** -- regression testing:
1. Start Joplin 3.3.5 with the KMinder-Mindmap-Plugin loaded as a development plugin.
2. Open a note and click the "mindmap" button.
   ![screenshot: Mindmap button highlighted in the toolbar](https://github.com/user-attachments/assets/2bd47bd5-2c6b-4c8e-95cc-3750c68e8974)
3. Verify that the mindmap dialog is visible
   ![screenshot: Mindmap dialog is visible](https://github.com/user-attachments/assets/8ab3aa6f-1fe8-433f-9dec-39665d82f243)
4. Make a change to the mindmap (see https://github.com/calandradas/Kminder-Mindmap-Joplin-Plugin/issues/7).
   ![screenshot: A "1" marker is now present on the main mindmap box](https://github.com/user-attachments/assets/2a95cdeb-c45e-44cd-8606-158a56d2d89c)
5. Click "save"
6. Verify that the mindmap has been added to the note
  ![screenshot: Mindmap included in note](https://github.com/user-attachments/assets/0fa6ba9f-b638-4f4f-bdbc-1905dcbec220)

**Windows 11**:
1. Start Joplin 3.3.5.
2. Install the built KMinder-Mindmap-Plugin JPL file ([from the build workflow](https://github.com/personalizedrefrigerator/fork-kminder-Mindmap-Joplin-Plugin/actions/runs/14604668071)).
3. Open a note and click the "mindmap" button.
4. Verify that the mindmap dialog is visible, with a few default nodes.
5. Make a change to the mindmap.
6. Click "save"
7. Verify that the mindmap has been added to the note
